### PR TITLE
Refactor TaskModel and SQL schema to use 'value' instead of 'name' for status identification

### DIFF
--- a/Models/TaskModel.php
+++ b/Models/TaskModel.php
@@ -159,7 +159,7 @@ class TaskModel extends Database implements IModel
         // If status is provided, update it as well
         if (isset($task['status'])) {
           // First, get the status ID from status name
-          $statusQuery = "SELECT id_status FROM status WHERE name = ?";
+          $statusQuery = "SELECT id_status FROM status WHERE value = ?";
           $statusResult = $this->selectOne($statusQuery, ["s", $task['status']]);
 
           if ($statusResult->id_status) {

--- a/SQL/insert.sql
+++ b/SQL/insert.sql
@@ -9,6 +9,6 @@ INSERT INTO role (name, role) VALUES ('Externe', 'external');
 INSERT INTO user (username, email, password, created_at, is_admin, id_role) VALUES ('admin', 'admin@gmail.com', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', NOW(), 1, @admin_role_id);
 INSERT INTO user (username, email, password, created_at, is_admin, id_role) VALUES ('user', 'user@gmail.com', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi', NOW(), 1, @dev_role_id);
 
-INSERT INTO status (name) VALUES ('À faire');
-INSERT INTO status (name) VALUES ('En cours');
-INSERT INTO status (name) VALUES ('Terminé');
+INSERT INTO status (name, value) VALUES ('À faire', 'a_faire');
+INSERT INTO status (name, value) VALUES ('En cours', 'en_cours');
+INSERT INTO status (name, value) VALUES ('Fait', 'fait');

--- a/SQL/tables.sql
+++ b/SQL/tables.sql
@@ -40,6 +40,7 @@ CREATE TABLE item(
 CREATE TABLE status(
    id_status INT AUTO_INCREMENT,
    name VARCHAR(50) ,
+   value VARCHAR(50) ,
    PRIMARY KEY(id_status)
 );
 


### PR DESCRIPTION
This pull request updates the handling of task statuses to use a new `value` field for status records, improving consistency between the database schema and application logic. The most important changes are grouped below:

**Database schema and data updates:**

* Added a new `value` column to the `status` table to store a machine-readable status identifier, in addition to the human-readable `name`. (`SQL/tables.sql`)
* Updated initial status records to include both `name` (display label) and `value` (identifier), and renamed the final status from "Terminé" to "Fait" with its corresponding value. (`SQL/insert.sql`)

**Application logic updates:**

* Modified status lookup in the `reorderTasks` method to use the new `value` field instead of `name` when updating a task's status, ensuring alignment with the updated schema. (`Models/TaskModel.php`)