### PR TITLE
Enhance project retrieval logic to include shared projects and access types

### DIFF
--- a/Models/ProjectModel.php
+++ b/Models/ProjectModel.php
@@ -43,8 +43,9 @@ class ProjectModel extends Database implements IModel
     if (array_key_exists('id', $args)) {
       $id = $args['id'];
       $query = <<<SQL
-        SELECT
+        (SELECT
           project.id_project,
+          'project_member' AS access_type,
           name,
           description,
           project.created_at,
@@ -67,11 +68,34 @@ class ProjectModel extends Database implements IModel
         LEFT JOIN projects ON projects.id_project = project.id_project
         LEFT JOIN user ON user.id_user = projects.id_user
         WHERE projects.id_user = ?
-        GROUP BY project.id_project
+        GROUP BY project.id_project)
+        UNION
+        (SELECT
+          project.id_project,
+          'shared' AS access_type,
+          name,
+          description,
+          project.created_at,
+          project.id_user AS created_by_id,
+          creator.username AS created_by_name,
+          modified_at as updated_at,
+          archived_at,
+          NULL as id_users,
+          NULL as users,
+          NULL as users_json
+        FROM project
+        LEFT JOIN user AS creator ON creator.id_user = project.id_user
+        WHERE project.id_project IN (
+          SELECT DISTINCT note.id_project
+          FROM note
+          JOIN shared ON note.id_item = shared.id_item
+          WHERE shared.id_user = ?
+        )
+        GROUP BY project.id_project)
         ORDER BY name ASC LIMIT ?
       SQL;
 
-      return $this->select($query, ["ii", $id, $limit]);
+      return $this->select($query, ["iii", $id, $id, $limit]);
     }
 
     $query = $this->baseQuery . <<<SQL


### PR DESCRIPTION
… 
This pull request updates the `getAll` method in `ProjectModel.php` to enhance how projects are retrieved for a user. The main improvement is that the query now returns both projects the user is a direct member of and projects that are shared with the user, making project access more comprehensive.

**Project access query improvements:**

* Modified the SQL query in `getAll` to use a `UNION` of two subqueries: one for projects where the user is a member (`access_type` set to `'project_member'`), and another for projects shared with the user (`access_type` set to `'shared'`). This allows the method to return all relevant projects for a user, regardless of how they have access. [[1]](diffhunk://#diff-233323b3d0a70ad5b68de827685ca08f0972c92179ba389d2dd813b10e886729L46-R48) [[2]](diffhunk://#diff-233323b3d0a70ad5b68de827685ca08f0972c92179ba389d2dd813b10e886729L70-R98)
* Updated the SQL parameter bindings to accommodate the new query structure, ensuring all necessary parameters are passed for both subqueries.